### PR TITLE
revisão do cookbook

### DIFF
--- a/Cookbook/cookbook.lua
+++ b/Cookbook/cookbook.lua
@@ -106,3 +106,6 @@ remove_stop_words()
 frequencies()
 sort()
 print_prefered_words()
+
+
+-- ver comentarios no pull-request (Roxana)


### PR DESCRIPTION
O programa não da os resultados esperados.
![pedro-cookbook](https://user-images.githubusercontent.com/1106435/27804643-da9bb0a6-5fe4-11e7-8aa3-74e249b0cd19.png)


observações:
- o [diagrama](https://github.com/pnalvarez/Trab2-PES-2017.1/blob/master/Cookbook/cookbookDiagram.pdf) não tem a função print_preferred_words()
- na linha 56, devería ser "../stop-words.txt" para ler o texto dos stop-words. Na mesma linha, a função _separa()_ vai dar erro pois não existe tal função.
- linha 57, a variavel _copy_  não é entendivel. ver a [regra 4](https://pes2006.wordpress.com/2006/03/15/disciplina/) da disciplina 
- linha 39. A argumentação precisa ser melhorada.  _"Função que verifica se uma palavra se encontra na tabela"_ que tabela? dos stopwords?. ver [regra 2](https://pes2006.wordpress.com/2006/03/15/disciplina/) da disciplina
- linha 49. No estilo não é utilizado _returns_ nas funções. As funções compartilham o estado na forma de variaveis globais. (ver no livro a pag 33)