### PR TITLE
revisão do kick-forward

### DIFF
--- a/Kick_Forward/kick_forward.lua
+++ b/Kick_Forward/kick_forward.lua
@@ -123,3 +123,4 @@ end
 
 --[Main]--
 read_file(arg[1], filter_chars)
+--ver comentario no pull-request (Roxana)


### PR DESCRIPTION
o código não executa corretamente: 
![kick-forward-pedro](https://user-images.githubusercontent.com/1106435/27805556-342eb366-5fea-11e7-9902-bbf757bf3c35.png)

- ver linha 62, deveria ser "../stop-words.txt"
- no [diagrama](https://github.com/pnalvarez/Trab2-PES-2017.1/blob/master/Kick_Forward/kick_forwardDiagram.pdf) um pai pode ter comunicação com os filhos,  a comunicação entre filhos não existe.
- a função no_op tem que ser chamada como no código da [Crista](https://github.com/crista/exercises-in-programming-style/blob/master/08-kick-forward/tf-08.py) ver linha 44. Isto não acontece no código, o no_op não é chamado.
- falta melhorar a argumentação das funções.
- sugestão: ver o _split_ de palavras em linha 78 de este [código](https://github.com/maumau27/PUC-Rio-INF1629-Trabalho_2/blob/master/Kick-Forward/kick-forward.lua)