### PR TITLE
revisão do monolith

### DIFF
--- a/Monolith/monolith.lua
+++ b/Monolith/monolith.lua
@@ -60,3 +60,5 @@ file= io.open("../pride-and-prejudice.txt", "r")
 
     for i =0,25 do table.insert(filter,word_freqs[i]) end
     for k,v in pairs(word_freqs) do io.write(v.word.."-"..v.frequency) end
+
+-- ver comentarios no pull-request (Roxana)


### PR DESCRIPTION
- o programa não executa corretamente
![monolith-pedro](https://user-images.githubusercontent.com/1106435/27807019-05696194-5ff3-11e7-94cc-b282e9032212.png)


- o estilo não tem o diagrama
- na linha 13 está fixo o "../pride-and-prejudice.txt". Deveria ler qualquer arquivo
- na linha 1 está comentado _"Estilo cookbook--]]"_
- só tem pré e pós-condições no inicio da função principal. ver [regra 2](https://pes2006.wordpress.com/2006/03/15/disciplina/) da disciplina

O peculiar do estilo monolith e o tratamento do código como era antigamente, sem uso o pouco uso de bibliotecas externas. 
para o exemplo das palavras frequentes, uma parte do código deveria iterar o arquivo linha por linha, verificando o inicio e fim de cada palavra, para depois verificar se a palavra é ou não alfanumerica. Finalmente a palavra é normalizada (lower)....  ver linhas (11-24 ) da [Crista](https://github.com/crista/exercises-in-programming-style/blob/master/03-monolith/tf-03.py)
No código de vocês isto é feito em 3 linhas (14-16) utilizando as funções de Lua.

Sugestão: verificar as [restrições do estilo](https://github.com/crista/exercises-in-programming-style/tree/master/03-monolith)